### PR TITLE
[v2] grc: Make exception for epy in blacklist id

### DIFF
--- a/grc/core/params/dtypes.py
+++ b/grc/core/params/dtypes.py
@@ -43,6 +43,9 @@ def validate_block_id(param,black_listed_ids):
     if not re.match(r'^[a-z|A-Z]\w*$', value):
         raise ValidateError('ID "{}" must begin with a letter and may contain letters, numbers, '
                             'and underscores.'.format(value))
+    # Epy blocks and modules are exempt from id check
+    if re.search('^epy', value):
+        return value
     if value in (black_listed_ids + ID_BLACKLIST):
         raise ValidateError('ID "{}" is blacklisted.'.format(value))
     block_names = [block.name for block in param.parent_flowgraph.iter_enabled_blocks()]


### PR DESCRIPTION
I refer to the mailing list thread on May 8 2021 regarding "Embedded
Python Block Tutorial Param ID Error".

The bug is caused by #4522 as names of embedded python blocks
such as `epy_block_0` are blacklisted because of "blocks" in the
argument `black_listed_ids`. It affects both embedded python blocks and
modules. This commit fixes the bug by granting exemption for these two
types of blocks from id validation.

Signed-off-by: Solomon Tan <solomonbstoner@yahoo.com.au>